### PR TITLE
Improved semaphore error handling

### DIFF
--- a/src/holodeck/environments.py
+++ b/src/holodeck/environments.py
@@ -508,14 +508,15 @@ class HolodeckEnvironment:
         pid = self._world_process.pid if hasattr(self, "_world_process") else None
         try:
             self._client.acquire()
-        except TimeoutError:
+        except TimeoutError as error:
             print("Engine error", file=sys.stderr)
             print("Check logs:\n{}\n".format("\n".join(log_paths())), file=sys.stderr)
+            # https://stackoverflow.com/a/792163
             raise HolodeckException(
                 "Timed out waiting for engine process to release semaphore. Is it frozen?"
                 if pid and check_process_alive(pid)
                 else "Engine process exited while attempting to acquire semaphore"
-            )
+            ) from error
 
     def _enqueue_command(self, command_to_send):
         self._command_center.enqueue_command(command_to_send)

--- a/src/holodeck/environments.py
+++ b/src/holodeck/environments.py
@@ -509,8 +509,10 @@ class HolodeckEnvironment:
         try:
             self._client.acquire()
         except TimeoutError as error:
+            print("***")
             print("Engine error", file=sys.stderr)
-            print("Check logs:\n{}\n".format("\n".join(log_paths())), file=sys.stderr)
+            print("Check logs:\n{}\n".format("\n- ".join(log_paths())), file=sys.stderr)
+            print("***")
             # https://stackoverflow.com/a/792163
             raise HolodeckException(
                 "Timed out waiting for engine process to release semaphore. Is it frozen?"

--- a/src/holodeck/environments.py
+++ b/src/holodeck/environments.py
@@ -515,7 +515,7 @@ class HolodeckEnvironment:
             print("***", file=sys.stderr)
             # https://stackoverflow.com/a/792163
             raise HolodeckException(
-                "Timed out waiting for engine process to release semaphore. Is it frozen?"
+                "Timed out waiting for engine process to release semaphore. Process is still running, is it frozen?"
                 if pid and check_process_alive(pid)
                 else "Engine process exited while attempting to acquire semaphore"
             ) from error

--- a/src/holodeck/environments.py
+++ b/src/holodeck/environments.py
@@ -511,7 +511,7 @@ class HolodeckEnvironment:
         except TimeoutError as error:
             print("***", file=sys.stderr)
             print("Engine error", file=sys.stderr)
-            print("Check logs:\n{}\n".format("\n- ".join(log_paths())), file=sys.stderr)
+            print("Check logs:\n{}".format("\n".join(log_paths())), file=sys.stderr)
             print("***", file=sys.stderr)
             # https://stackoverflow.com/a/792163
             raise HolodeckException(

--- a/src/holodeck/environments.py
+++ b/src/holodeck/environments.py
@@ -26,7 +26,7 @@ from holodeck.command import (
 from holodeck.exceptions import HolodeckException
 from holodeck.holodeckclient import HolodeckClient
 from holodeck.agents import AgentDefinition, SensorDefinition, AgentFactory
-from holodeck.util import check_process_alive
+from holodeck.util import check_process_alive, log_paths
 from holodeck.weather import WeatherController
 
 
@@ -505,6 +505,8 @@ class HolodeckEnvironment:
         try:
             self._client.acquire()
         except TimeoutError:
+            print("Engine error", file=sys.stderr)
+            print("Check logs:\n{}\n".format("\n".join(log_paths())), file=sys.stderr)
             raise HolodeckException(
                 "Timed out waiting for engine process to release semaphore. Is it frozen?"
                 if pid and check_process_alive(pid)

--- a/src/holodeck/environments.py
+++ b/src/holodeck/environments.py
@@ -509,10 +509,10 @@ class HolodeckEnvironment:
         try:
             self._client.acquire()
         except TimeoutError as error:
-            print("***")
+            print("***", file=sys.stderr)
             print("Engine error", file=sys.stderr)
             print("Check logs:\n{}\n".format("\n- ".join(log_paths())), file=sys.stderr)
-            print("***")
+            print("***", file=sys.stderr)
             # https://stackoverflow.com/a/792163
             raise HolodeckException(
                 "Timed out waiting for engine process to release semaphore. Is it frozen?"

--- a/src/holodeck/environments.py
+++ b/src/holodeck/environments.py
@@ -26,6 +26,7 @@ from holodeck.command import (
 from holodeck.exceptions import HolodeckException
 from holodeck.holodeckclient import HolodeckClient
 from holodeck.agents import AgentDefinition, SensorDefinition, AgentFactory
+from holodeck.util import check_process_alive
 from holodeck.weather import WeatherController
 
 
@@ -498,7 +499,7 @@ class HolodeckEnvironment:
                     self._total_ticks
                 )
             )
-    
+
     def _acquire_catch_crash(self):
         pid = self._world_process.pid if hasattr(self, "_world_process") else None
         try:
@@ -508,6 +509,7 @@ class HolodeckEnvironment:
                 "Timed out waiting for engine process to release semaphore. Is it frozen?"
                 if pid and check_process_alive(pid)
                 else "Engine process exited while attempting to acquire semaphore"
+            )
 
     def _enqueue_command(self, command_to_send):
         self._command_center.enqueue_command(command_to_send)

--- a/src/holodeck/holodeckclient.py
+++ b/src/holodeck/holodeckclient.py
@@ -85,7 +85,7 @@ class HolodeckClient:
 
         # Unfortunately, OSX doesn't support sem_timedwait(), so setting this timeout
         # does nothing.
-        self.timeout = 60 if self.should_timeout else None
+        self.timeout = 10 if self.should_timeout else None
 
         def posix_acquire_semaphore(sem):
             sem.acquire(self.timeout)

--- a/src/holodeck/holodeckclient.py
+++ b/src/holodeck/holodeckclient.py
@@ -90,9 +90,9 @@ class HolodeckClient:
         def posix_acquire_semaphore(sem):
             try:
                 sem.acquire(self.timeout)
-            except posix_ipc.BusyError:
+            except posix_ipc.BusyError as error:
                 # Raise a TimeoutError for consistency with Windows implementation
-                raise TimeoutError("Timed out or error waiting for engine!")
+                raise TimeoutError("Timed out or error waiting for engine!") from error
 
         def posix_release_semaphore(sem):
             sem.release()

--- a/src/holodeck/holodeckclient.py
+++ b/src/holodeck/holodeckclient.py
@@ -88,7 +88,11 @@ class HolodeckClient:
         self.timeout = 10 if self.should_timeout else None
 
         def posix_acquire_semaphore(sem):
-            sem.acquire(self.timeout)
+            try:
+                sem.acquire(self.timeout)
+            except posix_ipc.BusyError:
+                # Raise a TimeoutError for consistency with Windows implementation
+                raise TimeoutError("Timed out or error waiting for engine!")
 
         def posix_release_semaphore(sem):
             sem.release()

--- a/src/holodeck/util.py
+++ b/src/holodeck/util.py
@@ -160,3 +160,24 @@ def draw_point(env, loc, color=None, thickness=10.0):
     color = [255, 0, 0] if color is None else color
     command_to_send = DebugDrawCommand(3, loc, [0, 0, 0], color, thickness)
     env._enqueue_command(command_to_send)
+
+
+def _windows_check_process_alive(pid):
+    import win32process
+    import win32con
+
+    if win32process.GetExitCodeProcess(pid) == win32con.STILL_ACTIVE:
+        return True
+
+    return False
+
+
+def _linux_check_process_alive(pid):
+    return os.path.exists("/proc/{}".format(pid))
+
+
+def check_process_alive(pid):
+    if os.name == "posix":
+        return _linux_check_process_alive(pid)
+    if os.name == "nt":
+        return _windows_check_process_alive(pid)

--- a/src/holodeck/util.py
+++ b/src/holodeck/util.py
@@ -164,10 +164,18 @@ def draw_point(env, loc, color=None, thickness=10.0):
 
 
 def _windows_check_process_alive(pid):
+    import win32api
     import win32process
     import win32con
 
-    if win32process.GetExitCodeProcess(pid) == win32con.STILL_ACTIVE:
+    if (
+        win32process.GetExitCodeProcess(
+            win32api.OpenProcess(
+                win32con.PROCESS_QUERY_LIMITED_INFORMATION, win32con.FALSE, pid
+            )
+        )
+        == win32con.STILL_ACTIVE
+    ):
         return True
 
     return False


### PR DESCRIPTION
- [x] Test `_windows_check_process_alive` on a Windows machine
- [x] Print out log paths after an engine crash (will wait for Chris' PR: https://github.com/BYU-PCCL/holodeck/pull/439)